### PR TITLE
Improve deserialization and validation

### DIFF
--- a/ranking_api/models.py
+++ b/ranking_api/models.py
@@ -12,10 +12,15 @@ class Player(db.Model):
     """
     Player database model class
     """
+
+    NUM_OF_MATCHES_DEFAULT = 0
+    RATING_DEFAULT = 1000
+    USERNAME_MAX_LENGTH = 32
+
     __tablename__ = "players"
-    username = db.Column(db.String(32), primary_key=True, nullable=False, unique=True)
-    num_of_matches = db.Column(db.Integer, default=0, nullable=False)
-    rating = db.Column(db.Integer, default=1000, nullable=False)
+    username = db.Column(db.String(USERNAME_MAX_LENGTH), primary_key=True, nullable=False, unique=True)
+    num_of_matches = db.Column(db.Integer, default=NUM_OF_MATCHES_DEFAULT, nullable=False)
+    rating = db.Column(db.Integer, default=RATING_DEFAULT, nullable=False)
     matches = db.relationship("MatchPlayerRelation", back_populates="player", lazy='select')
 
     @validates("username")
@@ -27,8 +32,8 @@ class Player(db.Model):
             raise ValueError(f"{key} must be a string")
         if not value or len(value) < 1:
             raise ValueError(f"{key} must be at least 1 character long")
-        if len(value) > 32:
-            raise ValueError(f"{key} cannot be over 32 characters long")
+        if len(value) > self.USERNAME_MAX_LENGTH:
+            raise ValueError(f"{key} cannot be over {self.USERNAME_MAX_LENGTH} characters long")
         return value
 
     @validates("num_of_matches", "rating")
@@ -56,7 +61,7 @@ class Player(db.Model):
                 "description": "The users' name",
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 32
+                "maxLength": Player.USERNAME_MAX_LENGTH
             },
             "num_of_matches": {
                 "description": "Number of played matches",
@@ -77,8 +82,8 @@ class Player(db.Model):
         Deserialization method for user data
         """
         self.username = data["username"]
-        self.num_of_matches = data.get("num_of_matches", 0)
-        self.rating = data.get("rating", 1000)
+        self.num_of_matches = data.get("num_of_matches", self.NUM_OF_MATCHES_DEFAULT)
+        self.rating = data.get("rating", self.RATING_DEFAULT)
 
     def serialize(self, include_matches: bool = True) -> dict:
         """
@@ -100,15 +105,21 @@ class Match(db.Model):
     """
     Match database model class
     """
+
+    STATUS_DEFAULT = 0
+    TEAM_SCORE_DEFAULT = 0
+    LOCATION_MAX_LENGTH = 50
+    DESCRIPTION_MAX_LENGTH = 100
+
     __tablename__ = "matches"
     id = db.Column(db.Integer, primary_key=True, unique=True, nullable=False)
     location = db.Column(db.String(50), nullable=False)
     time = db.Column(db.DateTime, nullable=False)
     description = db.Column(db.String(100))
-    status = db.Column(db.Integer, default=0, nullable=False)
+    status = db.Column(db.Integer, default=STATUS_DEFAULT, nullable=False)
     rating_shift = db.Column(db.Integer)
-    team1_score = db.Column(db.Integer, default=0)
-    team2_score = db.Column(db.Integer, default=0)
+    team1_score = db.Column(db.Integer, default=TEAM_SCORE_DEFAULT)
+    team2_score = db.Column(db.Integer, default=TEAM_SCORE_DEFAULT)
     players = db.relationship('MatchPlayerRelation', back_populates='match', lazy='select')
 
     @validates("location")
@@ -120,8 +131,8 @@ class Match(db.Model):
             raise ValueError(f"{key} must be a string")
         if not value or len(value) < 1:
             raise ValueError(f"{key} must be 1 character or longer")
-        if len(value) > 50:
-            raise ValueError(f"{key} cannot be longer than 50 characters")
+        if len(value) > self.LOCATION_MAX_LENGTH:
+            raise ValueError(f"{key} cannot be longer than {self.LOCATION_MAX_LENGTH} characters")
         return value
 
     @validates("time")
@@ -141,8 +152,8 @@ class Match(db.Model):
         if value: # nullable
             if not isinstance(value, str):
                 raise ValueError(f"{key} must be in string format")
-            if len(value) > 100:
-                raise ValueError(f"{key} cannot be longer than 100 characters")
+            if len(value) > self.DESCRIPTION_MAX_LENGTH:
+                raise ValueError(f"{key} cannot be longer than {self.DESCRIPTION_MAX_LENGTH} characters")
         return value
 
     @validates("status")
@@ -174,7 +185,7 @@ class Match(db.Model):
         if not isinstance(value, int):
             raise ValueError(f"{key} must be an integer")
         if value < 0:
-            raise ValueError(f"{key} cannot be")
+            raise ValueError(f"{key} cannot be negative")
         return value
 
     @staticmethod
@@ -191,7 +202,7 @@ class Match(db.Model):
                 "description": "Physical location of the game",
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 50
+                "maxLength": Match.LOCATION_MAX_LENGTH
             },
             "time": {
                 "description": "UTC timestamp for the game starting time",
@@ -202,7 +213,7 @@ class Match(db.Model):
                 "description": "Optional description, e.g. hashtag for the game",
                 "anyOf": [
                     {"type": "string",
-                     "maxLength": 100
+                     "maxLength": Match.DESCRIPTION_MAX_LENGTH
                     },
                     {"type": "null"}
                 ],
@@ -243,10 +254,10 @@ class Match(db.Model):
         self.location = data["location"]
         self.time = ts_to_datetime(data["time"])  # Convert to datetime or raise BadRequest
         self.description = data.get("description")
-        self.status = data.get('status', 0)
+        self.status = data.get('status', self.STATUS_DEFAULT)
         self.rating_shift = data.get('rating_shift')
-        self.team1_score = data.get('team1_score', 0)
-        self.team2_score = data.get('team2_score', 0)
+        self.team1_score = data.get('team1_score', self.TEAM_SCORE_DEFAULT)
+        self.team2_score = data.get('team2_score', self.TEAM_SCORE_DEFAULT)
 
     def serialize(self, include_players: bool = True) -> dict:
         """

--- a/ranking_api/models.py
+++ b/ranking_api/models.py
@@ -18,7 +18,10 @@ class Player(db.Model):
     USERNAME_MAX_LENGTH = 32
 
     __tablename__ = "players"
-    username = db.Column(db.String(USERNAME_MAX_LENGTH), primary_key=True, nullable=False, unique=True)
+    username = db.Column(db.String(USERNAME_MAX_LENGTH),
+                         primary_key=True,
+                         nullable=False,
+                         unique=True)
     num_of_matches = db.Column(db.Integer, default=NUM_OF_MATCHES_DEFAULT, nullable=False)
     rating = db.Column(db.Integer, default=RATING_DEFAULT, nullable=False)
     matches = db.relationship("MatchPlayerRelation", back_populates="player", lazy='select')
@@ -153,7 +156,8 @@ class Match(db.Model):
             if not isinstance(value, str):
                 raise ValueError(f"{key} must be in string format")
             if len(value) > self.DESCRIPTION_MAX_LENGTH:
-                raise ValueError(f"{key} cannot be longer than {self.DESCRIPTION_MAX_LENGTH} characters")
+                raise ValueError(f"{key} cannot be longer than "
+                                 f"{self.DESCRIPTION_MAX_LENGTH} characters")
         return value
 
     @validates("status")

--- a/ranking_api/models.py
+++ b/ranking_api/models.py
@@ -240,13 +240,13 @@ class Match(db.Model):
         """
         Deserialization method for match data
         """
-        self.location = data.get('location')
-        self.time = ts_to_datetime(data.get('time'))  # Convert to datetime or raise BadRequest
-        self.description = data.get('description')
-        self.status = data.get('status')
+        self.location = data["location"]
+        self.time = ts_to_datetime(data["time"])  # Convert to datetime or raise BadRequest
+        self.description = data.get("description")
+        self.status = data.get('status', 0)
         self.rating_shift = data.get('rating_shift')
-        self.team1_score = data.get('team1_score')
-        self.team2_score = data.get('team2_score')
+        self.team1_score = data.get('team1_score', 0)
+        self.team2_score = data.get('team2_score', 0)
 
     def serialize(self, include_players: bool = True) -> dict:
         """

--- a/ranking_api/resources/match.py
+++ b/ranking_api/resources/match.py
@@ -76,18 +76,8 @@ class MatchCollection(Resource):
         except ValidationError as e:
             raise BadRequest(description=str(e)) from e
 
-        data = {
-            "location": request.json["location"],
-            "time": request.json["time"],
-            "description": request.json["description"],
-            "status": request.json["status"],
-            "rating_shift": request.json["rating_shift"],
-            "team1_score": request.json["team1_score"],
-            "team2_score": request.json["team2_score"]
-        }
-
         match = Match()
-        match.deserialize(data)
+        match.deserialize(request.json)
 
         # Match primary key is auto-incrementing ID and other data can be identical
         # -> No need for Integrity check here

--- a/ranking_api/resources/player.py
+++ b/ranking_api/resources/player.py
@@ -78,14 +78,8 @@ class PlayerCollection(Resource):
         except ValidationError as e:
             raise BadRequest(description=str(e)) from e
 
-        data = {
-            "username": request.json["username"],
-            "num_of_matches": request.json.get("num_of_matches"),
-            "rating": request.json.get("rating")
-        }
-
         player = Player()
-        player.deserialize(data)
+        player.deserialize(request.json)
 
         try:
             db.session.add(player)


### PR DESCRIPTION
- Call resource deserialization methods on POST handlers with `request.json` instead of manually parsing `data` dictionary
  - The parsing is already done in resource deserialization methods after the data validation passes
  - This prevents receiving HTTP500 error when optional fields are omitted from POST requests to creating new `Player` or `Match`.
- Add resource level constants, e.g. `NUM_OF_MATCHES_DEFAULT` and `USERNAME_MAX_LENGTH` to make the assignments in one place and only call these values on validators, schemas and when setting default values on deserialization.

Cause of the HTTP500 error:
1. Send a request to create a new object without optional field(s), e.g. try to create `Player` object without field `num_of_matches`
2. POST handler parses this data no `None` and forwards the data to `Player` deserialization method 
3. Deserialization method sees the existing key and attempts to assign `None` to `num_of_matches` field instead of the default value
4. Validators raise `ValueError` which causes HTTP500 Internal Server Error