### PR TITLE
Add JSON responses to errors

### DIFF
--- a/ranking_api/app.py
+++ b/ranking_api/app.py
@@ -111,7 +111,7 @@ def register_error_handlers(app: Flask):
         :param message: The error message.
         :return: Tuple containing the JSON response and HTTP status code.
         """
-        return {"error_code": error_code, "message": message}, error_code
+        return {"message": message}, error_code
 
     @auth.error_handler
     def handle_auth_error(error_code: int) -> Tuple[dict, int]:

--- a/ranking_api/app.py
+++ b/ranking_api/app.py
@@ -1,14 +1,16 @@
 """
 App factory module for creating the application.
 """
-from typing import Union
+from typing import Union, Tuple
 
 from flask import Flask
+from werkzeug.exceptions import HTTPException
 
 from .authentication import Keyring
 from .extensions import (
     db,
-    api
+    api,
+    auth
 )
 from .resources.player import (
     PlayerConverter,
@@ -39,6 +41,7 @@ def create_app(config_obj: Union[object, str] = "config.Config") -> Flask:
     register_converters(app)
     register_resources()
     register_extensions(app)
+    register_error_handlers(app)
 
     # Initialize keyring and create database tables if they do not exist yet
     with app.app_context():
@@ -91,3 +94,47 @@ def register_extensions(app: Flask):
 
     db.init_app(app)
     api.init_app(app)
+
+
+def register_error_handlers(app: Flask):
+    """
+    Register error handlers that return JSON responses for errors instead of the default plain text.
+
+    :param app: Flask app to register the error handlers for.
+    """
+
+    def build_response(error_code: int, message: str) -> Tuple[dict, int]:
+        """
+        Build JSON response for an error.
+
+        :param error_code: HTTP error code of the error.
+        :param message: The error message.
+        :return: Tuple containing the JSON response and HTTP status code.
+        """
+        return {"error_code": error_code, "message": message}, error_code
+
+    @auth.error_handler
+    def handle_auth_error(error_code: int) -> Tuple[dict, int]:
+        """
+        Handle authentication errors, meaning HTTP401 for invalid API token and HTTP403 if the
+        token is valid but is not authorized to complete a request.
+
+        :param error_code: Error code of the error.
+        :return: Tuple containing a JSON response and the HTTP status code.
+        """
+        if error_code == 401:
+            message = "Invalid API token."
+        else:
+            message = "Insufficient credentials for the request."
+
+        return build_response(error_code, message)
+
+    @app.errorhandler(HTTPException)
+    def handle_generic_error(error: HTTPException) -> Tuple[dict, int]:
+        """
+        Handle all generic HTTP errors.
+
+        :param error: The HTTP error.
+        :return: Tuple containing a JSON response and the HTTP status code.
+        """
+        return build_response(error.code, error.description)

--- a/ranking_api/resources/match.py
+++ b/ranking_api/resources/match.py
@@ -20,6 +20,7 @@ from jsonschema import (
 from ranking_api.extensions import api, db
 from ranking_api.authentication import auth
 from ranking_api.models import Match
+from .utils import fetch_validation_error
 
 
 class MatchItem(Resource):
@@ -74,8 +75,7 @@ class MatchCollection(Resource):
         try:
             validate(request.json, Match.json_schema(), format_checker=D7Validator.FORMAT_CHECKER)
         except ValidationError as e:
-            msg = f"{e.schema['description']}: {e.message}"
-            raise BadRequest(description=msg) from e
+            raise BadRequest(description=fetch_validation_error(e)) from e
 
         match = Match()
         match.deserialize(request.json)

--- a/ranking_api/resources/match.py
+++ b/ranking_api/resources/match.py
@@ -20,7 +20,7 @@ from jsonschema import (
 from ranking_api.extensions import api, db
 from ranking_api.authentication import auth
 from ranking_api.models import Match
-from .utils import validate_put_request_properties, fetch_validation_error
+from .utils import validate_put_request_properties, fetch_validation_error_message
 
 
 class MatchItem(Resource):
@@ -96,7 +96,7 @@ class MatchCollection(Resource):
         try:
             validate(request.json, Match.json_schema(), format_checker=D7Validator.FORMAT_CHECKER)
         except ValidationError as e:
-            raise BadRequest(description=fetch_validation_error(e)) from e
+            raise BadRequest(description=fetch_validation_error_message(e)) from e
 
         match = Match()
         match.deserialize(request.json)
@@ -122,7 +122,7 @@ class MatchConverter(BaseConverter):
 
         :param value: The match ID.
         :return: The Match object corresponding to the ID.
-        :raises: NotFound HTTP404 response if a Match object with the ID is not in database.
+        :raises: NotFound HTTP404 error if a Match object with the ID is not in database.
         """
         match = Match.query.filter_by(id=value).first()
         if match is None:

--- a/ranking_api/resources/match.py
+++ b/ranking_api/resources/match.py
@@ -74,7 +74,8 @@ class MatchCollection(Resource):
         try:
             validate(request.json, Match.json_schema(), format_checker=D7Validator.FORMAT_CHECKER)
         except ValidationError as e:
-            raise BadRequest(description=str(e)) from e
+            msg = f"{e.schema['description']}: {e.message}"
+            raise BadRequest(description=msg) from e
 
         match = Match()
         match.deserialize(request.json)

--- a/ranking_api/resources/match.py
+++ b/ranking_api/resources/match.py
@@ -67,7 +67,7 @@ class MatchItem(Resource):
         try:
             validate(new_data, Match.json_schema())
         except ValidationError as e:
-            raise BadRequest(description=str(e)) from e
+            raise BadRequest(description=fetch_validation_error(e)) from e
 
         match.deserialize(new_data)
         db.session.commit()

--- a/ranking_api/resources/match.py
+++ b/ranking_api/resources/match.py
@@ -95,7 +95,7 @@ class MatchConverter(BaseConverter):
     def to_python(self, value: str) -> Match:
         match = Match.query.filter_by(id=value).first()
         if match is None:
-            raise NotFound
+            raise NotFound(description=f"No such match with ID {value}")
         return match
 
     def to_url(self, value: Match) -> str:

--- a/ranking_api/resources/player.py
+++ b/ranking_api/resources/player.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import IntegrityError
 from ranking_api.extensions import api, db
 from ranking_api.authentication import auth
 from ranking_api.models import Player
-from .utils import str_to_bool, validate_put_request_properties, fetch_validation_error
+from .utils import str_to_bool, validate_put_request_properties, fetch_validation_error_message
 
 
 class PlayerItem(Resource):
@@ -98,7 +98,7 @@ class PlayerCollection(Resource):
         try:
             validate(request.json, Player.json_schema())
         except ValidationError as e:
-            raise BadRequest(description=fetch_validation_error(e)) from e
+            raise BadRequest(description=fetch_validation_error_message(e)) from e
 
         player = Player()
         player.deserialize(request.json)
@@ -126,7 +126,7 @@ class PlayerConverter(BaseConverter):
 
         :param value: The players' username.
         :return: The Player object corresponding to the username.
-        :raises: NotFound HTTP404 response if a Player object with the username is not in database.
+        :raises: NotFound HTTP404 error if a Player object with the username is not in database.
         """
         player = Player.query.filter_by(username=value).first()
         if player is None:

--- a/ranking_api/resources/player.py
+++ b/ranking_api/resources/player.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import IntegrityError
 from ranking_api.extensions import api, db
 from ranking_api.authentication import auth
 from ranking_api.models import Player
-from .utils import str_to_bool
+from .utils import str_to_bool, fetch_validation_error
 
 
 class PlayerItem(Resource):
@@ -76,8 +76,7 @@ class PlayerCollection(Resource):
         try:
             validate(request.json, Player.json_schema())
         except ValidationError as e:
-            msg = f"{e.schema['description']}: {e.message}"
-            raise BadRequest(description=msg) from e
+            raise BadRequest(description=fetch_validation_error(e)) from e
 
         player = Player()
         player.deserialize(request.json)

--- a/ranking_api/resources/player.py
+++ b/ranking_api/resources/player.py
@@ -76,7 +76,8 @@ class PlayerCollection(Resource):
         try:
             validate(request.json, Player.json_schema())
         except ValidationError as e:
-            raise BadRequest(description=str(e)) from e
+            msg = f"{e.schema['description']}: {e.message}"
+            raise BadRequest(description=msg) from e
 
         player = Player()
         player.deserialize(request.json)

--- a/ranking_api/resources/player.py
+++ b/ranking_api/resources/player.py
@@ -100,7 +100,7 @@ class PlayerConverter(BaseConverter):
     def to_python(self, value: str) -> Player:
         player = Player.query.filter_by(username=value).first()
         if player is None:
-            raise NotFound
+            raise NotFound(description=f"No such player with username {value}")
         return player
 
     def to_url(self, value: Player) -> str:

--- a/ranking_api/resources/player.py
+++ b/ranking_api/resources/player.py
@@ -61,7 +61,7 @@ class PlayerItem(Resource):
         try:
             validate(new_data, Player.json_schema())
         except ValidationError as e:
-            raise BadRequest(description=str(e)) from e
+            raise BadRequest(description=fetch_validation_error(e)) from e
 
         player.deserialize(new_data)
         db.session.commit()

--- a/ranking_api/resources/utils.py
+++ b/ranking_api/resources/utils.py
@@ -41,7 +41,7 @@ def ts_to_datetime(timestamp: str) -> datetime:
         raise BadRequest("Bad datetime format") from exc
 
 
-def fetch_validation_error(error: ValidationError):
+def fetch_validation_error_message(error: ValidationError):
     """
     Fetch a short and useful validation error message from a ValidationError.
     There is no need to send the full message with all field rules to the client.
@@ -59,10 +59,13 @@ def fetch_validation_error(error: ValidationError):
 def validate_put_request_properties(schema: dict, data: dict):
     """
     Validate received object properties for PUT requests. Raise an exception if validation fails.
+    This function temporarily makes all schema properties required, so use only when
+    that is needed.
 
     :param schema: The object schema to validate against.
     :param data: The received request data.
     :return: None if the data is valid, else raise a BadRequest error.
+    :raises: BadRequest HTTP400 error if object field validation fails.
     """
     # Update the schema to require all properties
     schema["required"] = list(schema["properties"].keys())
@@ -73,5 +76,5 @@ def validate_put_request_properties(schema: dict, data: dict):
         if list(data.keys()) != schema["required"]:
             msg = "All object fields are required in PUT requests."
         else:
-            msg = fetch_validation_error(e)
+            msg = fetch_validation_error_message(e)
         raise BadRequest(description=msg) from e

--- a/ranking_api/resources/utils.py
+++ b/ranking_api/resources/utils.py
@@ -5,6 +5,7 @@ Utility module for processing HTTP methods for resources.
 from datetime import datetime
 
 from werkzeug.exceptions import BadRequest
+from jsonschema import ValidationError
 
 
 def str_to_bool(value: str) -> bool:
@@ -39,3 +40,18 @@ def ts_to_datetime(timestamp: str) -> datetime:
         return datetime.fromisoformat(timestamp)
     except ValueError as exc:
         raise BadRequest("Bad datetime format") from exc
+
+
+def fetch_validation_error(error: ValidationError):
+    """
+    Fetch a short and useful validation error message from a ValidationError.
+    There is no need to send the full message with all field rules to the client.
+
+    :param error: The triggered ValidationError.
+    :return: An error message in format 'field_name: error_cause'
+    """
+    if error.validator == "required":
+        variable_name = error.validator_value[0]
+    else:
+        variable_name = error.relative_path[0]
+    return f"Error on value {variable_name}: {error.message}"


### PR DESCRIPTION
- Implement error handlers that return JSON response on errors instead of plain text messages
  - Error code can be read from the response status. Response body is in format 
    ```json 
    {"message": "error message"}
    ```
  - Covers errors 401 and 403 for authentication, and all errors derived from `HTTPException`. The error message is fetched from error description.
- Improve error descriptions on resource converters and validation errors so that they are compact and useful instead of default ones
  - On validation errors return message in format `field_name: fail_cause`
  - On 404 errors for converters, return `No such player with username {username}` and `No such match with ID {id}`

    