### PR TITLE
Add API token endpoints

### DIFF
--- a/ranking_api/app.py
+++ b/ranking_api/app.py
@@ -17,11 +17,15 @@ from .resources.player import (
     PlayerCollection,
     PlayerItem
 )
-
 from .resources.match import (
     MatchConverter,
     MatchCollection,
     MatchItem
+)
+from .resources.api_token import (
+    ApiTokenConverter,
+    ApiTokenCollection,
+    ApiTokenItem
 )
 
 from .resources.season import (
@@ -78,6 +82,7 @@ def register_converters(app: Flask):
     app.url_map.converters["player"] = PlayerConverter
     app.url_map.converters["match"] = MatchConverter
     app.url_map.converters["season"] = SeasonConverter
+    app.url_map.converters["api_token"] = ApiTokenConverter
 
 
 def register_resources():
@@ -93,6 +98,9 @@ def register_resources():
 
     api.add_resource(SeasonCollection, "/seasons/")
     api.add_resource(SeasonItem, "/seasons/<season:season>/")
+
+    api.add_resource(ApiTokenCollection, "/tokens/")
+    api.add_resource(ApiTokenItem, "/tokens/<api_token:api_token>/")
 
 
 def register_extensions(app: Flask):

--- a/ranking_api/authentication.py
+++ b/ranking_api/authentication.py
@@ -13,7 +13,7 @@ from ranking_api.extensions import auth, db
 from ranking_api.secret_models import ApiToken
 
 
-class UserCollisionError(Exception):
+class UserCollisionError(ValueError):
     """
     An exception raised when attempting to create an ApiToken with existing user into the Keyring.
     """
@@ -85,7 +85,7 @@ class Keyring:
         :return: The newly created ApiToken object.
         :raises ValueError: If user is not non-empty string. White space only is considered
                             as an empty string.
-        :raises UserCollisionError: If a toke n for the user already exists.
+        :raises UserCollisionError: If a token for the user already exists.
         """
         if not isinstance(user, str) or not user.strip():
             raise ValueError("User must be a non-empty string.")

--- a/ranking_api/authentication.py
+++ b/ranking_api/authentication.py
@@ -81,7 +81,7 @@ class Keyring:
         If current_app is in debug mode, the token is not saved into database.
 
         :param user: User to create the API token for.
-        :param role: Role for the users' token.
+        :param role: A special role for the users' token. None creates a regular token with admin rights.
         :return: The newly created ApiToken object.
         :raises ValueError: If user is not non-empty string. White space only is considered
                             as an empty string.

--- a/ranking_api/authentication.py
+++ b/ranking_api/authentication.py
@@ -13,6 +13,12 @@ from ranking_api.extensions import auth, db
 from ranking_api.secret_models import ApiToken
 
 
+class UserCollisionError(Exception):
+    """
+    An exception raised when attempting to create an ApiToken with existing user into the Keyring.
+    """
+
+
 class Keyring:
     """
     A keyring object that handles API tokens for the application.
@@ -76,14 +82,15 @@ class Keyring:
 
         :param user: User to create the API token for.
         :return: The newly created ApiToken object.
-        :raises ValueError: If a token for the user already exists or user is not non-empty string.
-                            White space only is considered as an empty string.
+        :raises ValueError: If user is not non-empty string. White space only is considered
+                            as an empty string.
+        :raises UserCollisionError: If a toke n for the user already exists.
         """
         if not isinstance(user, str) or not user.strip():
-            raise ValueError("User must be an instance of non-empty string")
+            raise ValueError("User must be a non-empty string.")
         if self.__get_token_by_user(user):
-            raise ValueError(f"API token for user {user} already exists. Use update_token to "
-                             f"generate a new token for existing ApiToken.")
+            raise UserCollisionError(f"API token for user {user} already exists. Use update_token to "
+                                     f"generate a new token for existing ApiToken.")
 
         api_token = ApiToken(token=str(self.__generate_token()),
                              user=user,

--- a/ranking_api/authentication.py
+++ b/ranking_api/authentication.py
@@ -81,7 +81,8 @@ class Keyring:
         If current_app is in debug mode, the token is not saved into database.
 
         :param user: User to create the API token for.
-        :param role: A special role for the users' token. None creates a regular token with admin rights.
+        :param role: A special role for the users' token. None creates a regular
+                     token with admin rights.
         :return: The newly created ApiToken object.
         :raises ValueError: If user is not non-empty string. White space only is considered
                             as an empty string.

--- a/ranking_api/resources/api_token.py
+++ b/ranking_api/resources/api_token.py
@@ -11,7 +11,6 @@ from ranking_api.authentication import auth, UserCollisionError
 from ranking_api.secret_models import ApiToken
 from ranking_api.extensions import db
 
-# TODO: Add roles
 
 class ApiTokenItem(Resource):
     """
@@ -21,7 +20,7 @@ class ApiTokenItem(Resource):
     """
 
     @staticmethod
-    @auth.login_required
+    @auth.login_required(role="super admin")
     def get(api_token: ApiToken):
         """
         GET method handler to fetch a serialized ApiToken object from the database.
@@ -33,7 +32,7 @@ class ApiTokenItem(Resource):
         return api_token.serialize()
 
     @staticmethod
-    @auth.login_required
+    @auth.login_required(role="super admin")
     def delete(api_token: ApiToken):
         """
         DELETE method handler to delete an ApiToken object from the database.
@@ -46,7 +45,7 @@ class ApiTokenItem(Resource):
         return Response(status=204)
 
     @staticmethod
-    @auth.login_required
+    @auth.login_required(role="super admin")
     def patch(api_token: ApiToken):
         """
         PATCH method handler to update a token for existing ApiToken object in the database.
@@ -65,7 +64,7 @@ class ApiTokenCollection(Resource):
     """
 
     @staticmethod
-    @auth.login_required
+    @auth.login_required(role="super admin")
     def get():
         """
         GET method handler to fetch collection of ApiToken objects from the database.
@@ -76,14 +75,15 @@ class ApiTokenCollection(Resource):
         return [api_token.serialize() for api_token in api_tokens]
 
     @staticmethod
-    @auth.login_required
+    @auth.login_required(role="super admin")
     def post():
         """
         POST method handler to create a new ApiToken object for a user into the database.
+        User for the token must be specified in query parameter 'user'.
 
         :return: HTTP201 response with the created ApiToken object serialized in the response body.
-                 HTTP400 response if query parameter user is missing.
-                 HTTP409 response if a token for the user already exists.
+        :raises BadRequest: HTTP400 error if user query parameter is missing or is invalid.
+        :raises Conflict: HTTP409 error if a token for the user already exists.
         """
         try:
             user = request.args["user"]

--- a/ranking_api/resources/api_token.py
+++ b/ranking_api/resources/api_token.py
@@ -79,7 +79,9 @@ class ApiTokenCollection(Resource):
     def post():
         """
         POST method handler to create a new ApiToken object for a user into the database.
-        User for the token must be specified in query parameter 'user'.
+        User for the token must be specified in query parameter 'user'. Query parameter
+        'role' can optionally be given to give the token a specific role. Default value creates a
+        regular admin token.
 
         :return: HTTP201 response with the created ApiToken object serialized in the response body.
         :raises BadRequest: HTTP400 error if user query parameter is missing or is invalid.
@@ -87,6 +89,7 @@ class ApiTokenCollection(Resource):
         """
         try:
             user = request.args["user"]
+            role = request.args.get("role")
         except KeyError as e:
             msg = "Query parameter user is required to create an API token."
             raise BadRequest(description=msg) from e
@@ -94,7 +97,7 @@ class ApiTokenCollection(Resource):
         keyring = current_app.config["KEYRING"]
         try:
             with current_app.app_context():
-                api_token = keyring.create_token(user)
+                api_token = keyring.create_token(user, role)
         except UserCollisionError as e:
             raise Conflict(description=f"Token for user {user} already exists.") from e
         except ValueError as e:

--- a/ranking_api/resources/api_token.py
+++ b/ranking_api/resources/api_token.py
@@ -1,3 +1,6 @@
+"""
+API representation of API token resources.
+"""
 from flask import request, current_app, Response
 from flask_restful import Resource
 
@@ -11,15 +14,33 @@ from ranking_api.extensions import db
 # TODO: Add roles
 
 class ApiTokenItem(Resource):
+    """
+    Represents a singe ApiToken resource and its HTTP methods in the API.
+    ApiTokenConverter is used to pair a user to an actual ApiToken object during requests.
+    HTTP404 is raised if an ApiToken with user does not exist.
+    """
 
     @staticmethod
     @auth.login_required
     def get(api_token: ApiToken):
+        """
+        GET method handler to fetch a serialized ApiToken object from the database.
+
+        :param api_token: The ApiToken object.
+        :return: HTTP200 response with The ApiToken object as a serialized JSON in
+                 the response body.
+        """
         return api_token.serialize()
 
     @staticmethod
     @auth.login_required
     def delete(api_token: ApiToken):
+        """
+        DELETE method handler to delete an ApiToken object from the database.
+
+        :param api_token: The ApiToken object to delete.
+        :return: HTTP204 response.
+        """
         db.session.delete(api_token)
         db.session.commit()
         return Response(status=204)
@@ -27,26 +48,48 @@ class ApiTokenItem(Resource):
     @staticmethod
     @auth.login_required
     def patch(api_token: ApiToken):
+        """
+        PATCH method handler to update a token for existing ApiToken object in the database.
+
+        :param api_token: The ApiToken object to update token for.
+        :return: HTTP200 response with the updated ApiToken object in response body.
+        """
         keyring = current_app.config["KEYRING"]
         api_token = keyring.update_token(api_token.user)
         return api_token.serialize(), 200
 
 
 class ApiTokenCollection(Resource):
+    """
+    Represents a collection of API tokens and HTTP methods for collection requests.
+    """
 
     @staticmethod
     @auth.login_required
     def get():
+        """
+        GET method handler to fetch collection of ApiToken objects from the database.
+
+        :return: HTTP200 response with a list of ApiToken objects as serialized JSONs in the body.
+        """
         api_tokens = ApiToken.query.all()
         return [api_token.serialize() for api_token in api_tokens]
 
     @staticmethod
     @auth.login_required
     def post():
+        """
+        POST method handler to create a new ApiToken object for a user into the database.
+
+        :return: HTTP201 response with the created ApiToken object serialized in the response body.
+                 HTTP400 response if query parameter user is missing.
+                 HTTP409 response if a token for the user already exists.
+        """
         try:
             user = request.args["user"]
-        except KeyError:
-            raise BadRequest(description="Query parameter user is required to create an API token.")
+        except KeyError as e:
+            msg = "Query parameter user is required to create an API token."
+            raise BadRequest(description=msg) from e
 
         keyring = current_app.config["KEYRING"]
         try:
@@ -59,12 +102,29 @@ class ApiTokenCollection(Resource):
 
 
 class ApiTokenConverter(BaseConverter):
+    """
+    A converter class responsible for ApiToken object conversions for ApiTokenItem methods.
+    Converts users from requests to ApiToken objects, or vice versa ApiToken objects to users.
+    """
 
     def to_python(self, value: str) -> ApiToken:
+        """
+        Convert a user to an ApiToken object.
+
+        :param value: The ApiToken user.
+        :return: The ApiToken object corresponding to the user.
+        :raises NotFound: HTTP404 error if an ApiToken object with the user is not in database.
+        """
         api_token = ApiToken.query.filter_by(user=value).first()
         if api_token is None:
             raise NotFound(description=f"No such API token with user {value}")
         return api_token
 
     def to_url(self, value: ApiToken) -> str:
+        """
+        Convert an ApiToken object to string containing its user.
+
+        :param value: The ApiToken object.
+        :return: The ApiToken user.
+        """
         return value.user

--- a/ranking_api/resources/api_token.py
+++ b/ranking_api/resources/api_token.py
@@ -1,0 +1,70 @@
+from flask import request, current_app, Response
+from flask_restful import Resource
+
+from werkzeug.routing import BaseConverter
+from werkzeug.exceptions import Conflict, BadRequest, NotFound
+
+from ranking_api.authentication import auth
+from ranking_api.secret_models import ApiToken
+from ranking_api.extensions import db
+
+# TODO: Add roles
+
+class ApiTokenItem(Resource):
+
+    @staticmethod
+    @auth.login_required
+    def get(api_token: ApiToken):
+        return api_token.serialize()
+
+    @staticmethod
+    @auth.login_required
+    def delete(api_token: ApiToken):
+        db.session.delete(api_token)
+        db.session.commit()
+        return Response(status=204)
+
+    @staticmethod
+    @auth.login_required
+    def patch(api_token: ApiToken):
+        keyring = current_app.config["KEYRING"]
+        api_token = keyring.update_token(api_token.user)
+        return api_token.serialize(), 200
+
+
+class ApiTokenCollection(Resource):
+
+    @staticmethod
+    @auth.login_required
+    def get():
+        api_tokens = ApiToken.query.all()
+        return [api_token.serialize() for api_token in api_tokens]
+
+    @staticmethod
+    @auth.login_required
+    def post():
+        try:
+            user = request.args["user"]
+        except KeyError:
+            raise BadRequest(description="Query parameter user is required to create an API token.")
+
+        keyring = current_app.config["KEYRING"]
+        try:
+            with current_app.app_context():
+                api_token = keyring.create_token(user)
+        except ValueError as e:
+            raise Conflict(description=f"Token for user {user} already exists.") from e
+
+        return api_token.serialize(), 201
+
+
+class ApiTokenConverter(BaseConverter):
+
+    def to_python(self, value: str) -> ApiToken:
+        api_token = ApiToken.query.filter_by(user=value).first()
+        if api_token is None:
+            raise NotFound(description=f"No such API token with user {value}")
+        return api_token
+
+    def to_url(self, value: ApiToken) -> str:
+        return value.user

--- a/ranking_api/secret_models.py
+++ b/ranking_api/secret_models.py
@@ -66,3 +66,9 @@ class ApiToken(db.Model):
 
         current_time = datetime.now(timezone.utc).replace(tzinfo=None)
         return self.expires_in < current_time
+
+    def serialize(self):
+        return {"token": self.token,
+                "user": self.user,
+                "expires_in": str(self.expires_in),
+                "created_at": str(self.created_at)}

--- a/ranking_api/secret_models.py
+++ b/ranking_api/secret_models.py
@@ -68,6 +68,11 @@ class ApiToken(db.Model):
         return self.expires_in < current_time
 
     def serialize(self):
+        """
+        Serialize an ApiToken object.
+
+        :return: The ApiToken object serialized as dictionary.
+        """
         return {"token": self.token,
                 "user": self.user,
                 "expires_in": str(self.expires_in),

--- a/ranking_api/secret_models.py
+++ b/ranking_api/secret_models.py
@@ -18,13 +18,14 @@ class ApiToken(db.Model):
 
     token = db.Column(db.String(36), primary_key=True)
     user = db.Column(db.String(32), nullable=False, unique=True)
+    role = db.Column(db.String(32), nullable=True)
     expires_in = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, nullable=False)
 
     def __str__(self):
         return self.token
 
-    @validates("token", "user")
+    @validates("token", "user", "role")
     def validate_string_fields(self, key, value):
         """
         Validate assigned string properties.
@@ -34,6 +35,10 @@ class ApiToken(db.Model):
         :return: Value of the property if valid.
         :raises ValueError: If the value is not a string or contains no textual data.
         """
+        if key == "role" and value is None:
+            # Special case for nullable role field
+            return value
+
         if not isinstance(value, str):
             raise ValueError(f"{key} must be a string.")
         if not value.strip():
@@ -75,5 +80,6 @@ class ApiToken(db.Model):
         """
         return {"token": self.token,
                 "user": self.user,
+                "role": self.role,
                 "expires_in": str(self.expires_in),
                 "created_at": str(self.created_at)}

--- a/tests/authentication_tests.py
+++ b/tests/authentication_tests.py
@@ -165,6 +165,22 @@ class TestApiToken:
 
         assert str(api_token) == token
 
+    def test_serialize(self):
+        """
+        Test the ApiToken serialization functionality.
+        """
+
+        current_time = datetime.now(timezone.utc).replace(tzinfo=None)
+        api_token = ApiToken(token="some token",
+                             user="testing",
+                             expires_in=current_time,
+                             created_at=current_time)
+
+        assert api_token.serialize() == {"token": "some token",
+                                         "user": "testing",
+                                         "expires_in": str(current_time),
+                                         "created_at": str(current_time)}
+
     def test_is_expired(self):
         """
         Test the ApiToken.is_expired functionality.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,3 +46,12 @@ def auth_header(test_app):  # pylint: disable=W0621
     with test_app.app_context():
         api_token = test_app.config["KEYRING"].create_token("tests")
         return {"Authorization": f"Bearer {api_token}"}
+
+@pytest.fixture(scope="function")
+def auth_header_superadmin(test_app):  # pylint: disable=W0621
+    """
+    Get super admin Authorization header with a Bearer token for requests.
+    """
+    with test_app.app_context():
+        api_token = test_app.config["KEYRING"].create_token("tests superadmin", role="super admin")
+        return {"Authorization": f"Bearer {api_token}"}

--- a/tests/db_test.py
+++ b/tests/db_test.py
@@ -666,6 +666,7 @@ def test_api_token_serialize(db_session):
     api_token = ApiToken.query.filter_by(user="testing").first()
     assert api_token.serialize() == {"token": token,
                                      "user": "testing",
+                                     "role": None,
                                      "expires_in": str(time),
                                      "created_at": str(time)}
 


### PR DESCRIPTION
 - Add role field for `ApiToken` objects. This supports setting required role(s) in `login_required` decorators.
- Add resources `ApiTokenItem` and `ApiTokenCollection` for API tokens
  - All requests to these resources require API token with role `super admin`
  - `ApiTokenItem` supports GET, DELETE and PATCH methods. PATCH is for regenerating tokens for users.
  - `ApiTokenCollection` supports GET and POST methods. POST request requires query parameter `user` for user specific token generation and does not fetch any other data, ad supports optional `role` query parameter for token role.